### PR TITLE
fix: tauri dev 起動時に bin ターゲットを明示する

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,6 +4,8 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version = "1.82"
+# bin が gen-bindings と 2 つあるため、`cargo run` の既定を明示する（tauri dev が使う）。
+default-run = "tauri-app-template"
 
 # RS-01: モバイル対応のため lib target を用意し、main.rs と mobile 双方から
 # `tauri_app_template_lib::run()` を呼び出す。


### PR DESCRIPTION
## Summary
- src-tauri に main.rs (bin: tauri-app-template) と bin/gen-bindings.rs の2つの bin ターゲットが存在し、`default-run` 未設定だと `cargo run`（`pnpm tauri dev` が内部で呼ぶ）が実行対象を決定できずエラーになっていた
- `default-run = "tauri-app-template"` を追加して既定の実行バイナリを明示

Closes #35

## Test plan
- [x] `cargo fmt --all -- --check`