### PR TITLE
fix(hooks): pre-push の diff 基準を @{push} から origin/main に変更する

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,12 +19,14 @@ pre-push:
     frontend-test:
       run: pnpm exec vitest run
     rust-core-test:
-      # crates/core の変更がある場合のみ実行し、待ち時間を抑える（R-15）
-      files: git diff --name-only @{push} HEAD
+      # crates/core の変更がある場合のみ実行し、待ち時間を抑える（R-15）。
+      # @{push} は新規ブランチの初回 push 時に upstream 未設定で解決できず
+      # exit 128 になるため、常に存在する origin/main を差分の基準にする。
+      files: git diff --name-only origin/main...HEAD
       glob: "crates/core/**/*.rs"
       run: cargo test -p app-core
     rust-tauri-clippy:
-      files: git diff --name-only @{push} HEAD
+      files: git diff --name-only origin/main...HEAD
       glob: "src-tauri/**/*.rs"
       run: cargo clippy -p tauri-app-template --all-targets -- -D warnings
 


### PR DESCRIPTION
## Summary
- 新規ブランチの初回 push 時、`@{push}` が upstream 未設定で解決できず `rust-core-test` / `rust-tauri-clippy` の `files` フィルタが exit 128 になり、pre-push フック全体が失敗して push できなくなる不具合を修正
- 常に存在する `origin/main` との diff に基準を切り替えた

Issue 対応ではない（後続の Issue 対応 PR を push するために先に直す必要があったインフラ修正）。

## Test plan
- [x] `git push` で pre-push フックが正常終了することを確認済み