### PR TITLE
fix(toast): エラートーストを自動 dismiss し、積み上がりを防ぐ

### DIFF
--- a/src/components/toaster.tsx
+++ b/src/components/toaster.tsx
@@ -7,7 +7,7 @@ export function Toaster() {
   if (toasts.length === 0) return null;
 
   return (
-    <div className="fixed bottom-safe-bottom right-4 z-50 flex flex-col gap-2 p-4">
+    <output className="fixed bottom-safe-bottom right-4 z-50 flex flex-col gap-2 p-4">
       {toasts.map((toast) => (
         <button
           type="button"
@@ -22,6 +22,6 @@ export function Toaster() {
           {toast.title}
         </button>
       ))}
-    </div>
+    </output>
   );
 }

--- a/src/stores/toast-store.test.ts
+++ b/src/stores/toast-store.test.ts
@@ -1,9 +1,15 @@
-import { beforeEach, describe, expect, it } from "vitest";
-import { useToastStore } from "./toast-store";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { TOAST_DURATION_MS, TOAST_LIMIT, useToastStore } from "./toast-store";
 
 describe("useToastStore", () => {
   beforeEach(() => {
+    vi.useFakeTimers();
     useToastStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
   it("starts with no toasts", () => {
@@ -35,5 +41,66 @@ describe("useToastStore", () => {
     useToastStore.getState().dismiss(toast.id);
 
     expect(useToastStore.getState().toasts).toEqual([]);
+  });
+
+  it("auto-dismisses a toast after TOAST_DURATION_MS", () => {
+    useToastStore.getState().push({ title: "Auto" });
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+
+    vi.advanceTimersByTime(TOAST_DURATION_MS);
+
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+
+  it("does not dismiss a toast before TOAST_DURATION_MS has elapsed", () => {
+    useToastStore.getState().push({ title: "Auto" });
+
+    vi.advanceTimersByTime(TOAST_DURATION_MS - 1);
+
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+  });
+
+  it("caps the number of visible toasts, dropping the oldest first", () => {
+    for (let i = 0; i < TOAST_LIMIT + 2; i++) {
+      useToastStore.getState().push({ title: `Toast ${i}` });
+    }
+
+    const toasts = useToastStore.getState().toasts;
+    expect(toasts).toHaveLength(TOAST_LIMIT);
+    expect(toasts.map((t) => t.title)).toEqual([
+      "Toast 2",
+      "Toast 3",
+      "Toast 4",
+      "Toast 5",
+      "Toast 6",
+    ]);
+  });
+
+  it("merges a duplicate consecutive push into the existing toast instead of stacking", () => {
+    useToastStore.getState().push({ title: "Network error", variant: "destructive" });
+    useToastStore.getState().push({ title: "Network error", variant: "destructive" });
+
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+  });
+
+  it("resets the auto-dismiss timer when a duplicate push arrives", () => {
+    useToastStore.getState().push({ title: "Network error", variant: "destructive" });
+
+    vi.advanceTimersByTime(TOAST_DURATION_MS - 1);
+    useToastStore.getState().push({ title: "Network error", variant: "destructive" });
+    vi.advanceTimersByTime(TOAST_DURATION_MS - 1);
+
+    expect(useToastStore.getState().toasts).toHaveLength(1);
+
+    vi.advanceTimersByTime(1);
+
+    expect(useToastStore.getState().toasts).toEqual([]);
+  });
+
+  it("does not merge pushes with a different title or variant", () => {
+    useToastStore.getState().push({ title: "Network error", variant: "destructive" });
+    useToastStore.getState().push({ title: "Network error" });
+
+    expect(useToastStore.getState().toasts).toHaveLength(2);
   });
 });

--- a/src/stores/toast-store.ts
+++ b/src/stores/toast-store.ts
@@ -6,21 +6,63 @@ export interface Toast {
   variant?: "default" | "destructive";
 }
 
+/** トーストが自動で消えるまでの時間。 */
+export const TOAST_DURATION_MS = 5000;
+/** 同時に表示できるトーストの最大件数。超えた分は古いものから捨てる。 */
+export const TOAST_LIMIT = 5;
+
 interface ToastState {
   toasts: Toast[];
   push: (toast: Omit<Toast, "id">) => void;
   dismiss: (id: string) => void;
 }
 
+const dismissTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function clearDismissTimer(id: string) {
+  const timer = dismissTimers.get(id);
+  if (timer) clearTimeout(timer);
+  dismissTimers.delete(id);
+}
+
 /**
  * FE-05: Rust 側エラーの共通表示先。`src/lib/api/**` で捕まえた例外や
  * ErrorBoundary はここに push し、`src/components/toaster.tsx` が描画する。
  */
-export const useToastStore = create<ToastState>((set) => ({
-  toasts: [],
-  push: (toast) =>
-    set((state) => ({
-      toasts: [...state.toasts, { ...toast, id: crypto.randomUUID() }],
-    })),
-  dismiss: (id) => set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) })),
-}));
+export const useToastStore = create<ToastState>((set, get) => {
+  function scheduleDismiss(id: string) {
+    clearDismissTimer(id);
+    dismissTimers.set(
+      id,
+      setTimeout(() => {
+        get().dismiss(id);
+      }, TOAST_DURATION_MS),
+    );
+  }
+
+  return {
+    toasts: [],
+    push: (toast) =>
+      set((state) => {
+        const last = state.toasts[state.toasts.length - 1];
+        if (last && last.title === toast.title && last.variant === toast.variant) {
+          scheduleDismiss(last.id);
+          return state;
+        }
+
+        const id = crypto.randomUUID();
+        const toasts = [...state.toasts, { ...toast, id }];
+        const overflow = Math.max(0, toasts.length - TOAST_LIMIT);
+        for (const dropped of toasts.slice(0, overflow)) {
+          clearDismissTimer(dropped.id);
+        }
+
+        scheduleDismiss(id);
+        return { toasts: toasts.slice(overflow) };
+      }),
+    dismiss: (id) => {
+      clearDismissTimer(id);
+      set((state) => ({ toasts: state.toasts.filter((t) => t.id !== id) }));
+    },
+  };
+});


### PR DESCRIPTION
## Summary
- `useToastStore.push` に 5 秒（`TOAST_DURATION_MS`）の自動 dismiss タイマーを追加
- 表示件数の上限（`TOAST_LIMIT` = 5 件）を設け、超過分は古いものから破棄
- 同一内容（title + variant）の連続 push は新規追加せず、既存トーストのタイマーをリセットして重複表示を防止
- `src/components/toaster.tsx` はスクリーンリーダー向けに `<output>` 要素（暗黙の `role="status"` / `aria-live="polite"`）へ変更

## Test plan
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm exec vitest run`（`toast-store.test.ts` に自動 dismiss / 上限 / 重複マージのケースを追加）

Closes #39