### PR TITLE
fix(demo): 通知権限の状態を画面表示し、dev実行時の既知の制約を明記

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -127,3 +127,12 @@ app_core::CoreError  →  src-tauri::AppError (#[from])  →  serde  →  フロ
 - Rust 側は `src-tauri/src/specta_bindings.rs` が `#[cfg(desktop)]` / `#[cfg(mobile)]` で
   別々の `typed_builder()` を持ち、デスクトップ専用コマンド（`updater`）はモバイル向け
   バイナリに含まれない
+
+## 12. 既知の制約
+
+- **macOS の dev 実行ではネイティブ通知が表示されないことがある（#37）** — `pnpm tauri dev` は
+  `.app` バンドルではなく `target/debug/` の生バイナリを直接起動する。macOS の通知センターは
+  バンドル ID を持たないプロセスからの通知をエラーを返さずに破棄するため、
+  `notification:default` の capabilities が正しくても通知が出ない。動作確認は
+  `pnpm tauri build` で生成した `.app` から起動して行う。`src/routes/demo.tsx` の
+  `NotificationDemo` は `isPermissionGranted()` の結果を画面に表示し、この注記も併記する

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -23,7 +23,11 @@
       "title": "Native notification",
       "send": "Send notification",
       "body": "This is a test notification",
-      "denied": "Notification permission was not granted"
+      "denied": "Notification permission was not granted",
+      "permissionGranted": "Permission: granted",
+      "permissionNotGranted": "Permission: not granted",
+      "permissionChecking": "Checking permission",
+      "devNote": "When launched with pnpm tauri dev, macOS Notification Center discards notifications from processes without a bundle ID, so notifications may not appear. Verify with a build from pnpm tauri build instead."
     },
     "openLink": { "title": "External link", "open": "Open in browser" },
     "longTask": { "title": "Async task with progress", "start": "Start", "cancel": "Cancel" },

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -23,7 +23,11 @@
       "title": "ネイティブ通知",
       "send": "通知を送信",
       "body": "テスト通知です",
-      "denied": "通知の権限が許可されていません"
+      "denied": "通知の権限が許可されていません",
+      "permissionGranted": "権限: 許可済み",
+      "permissionNotGranted": "権限: 未許可",
+      "permissionChecking": "権限を確認中",
+      "devNote": "pnpm tauri dev で起動した場合、macOS の通知センターがバンドルIDを持たないプロセスからの通知を破棄するため、通知が表示されないことがあります。動作確認は pnpm tauri build で生成したアプリから行ってください。"
     },
     "openLink": { "title": "外部リンク", "open": "ブラウザで開く" },
     "longTask": { "title": "進捗付き非同期処理", "start": "開始", "cancel": "キャンセル" },

--- a/src/routes/demo.test.tsx
+++ b/src/routes/demo.test.tsx
@@ -1,0 +1,59 @@
+import i18n from "@/app/i18n";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { NotificationDemo } from "./demo";
+
+const { isPermissionGranted, requestPermission, sendNotification } = vi.hoisted(() => ({
+  isPermissionGranted: vi.fn(),
+  requestPermission: vi.fn(),
+  sendNotification: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-notification", () => ({
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+}));
+
+describe("NotificationDemo", () => {
+  it("shows the granted permission status once isPermissionGranted resolves", async () => {
+    isPermissionGranted.mockResolvedValue(true);
+
+    render(<NotificationDemo onError={vi.fn()} />);
+
+    expect(screen.getByText(i18n.t("demo.notification.permissionChecking"))).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t("demo.notification.permissionGranted"))).toBeInTheDocument();
+    });
+  });
+
+  it("shows the dev-mode note about macOS discarding un-bundled notifications", async () => {
+    isPermissionGranted.mockResolvedValue(true);
+
+    render(<NotificationDemo onError={vi.fn()} />);
+
+    expect(screen.getByText(i18n.t("demo.notification.devNote"))).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText(i18n.t("demo.notification.permissionGranted"))).toBeInTheDocument();
+    });
+  });
+
+  it("reports the denied error and updates the status when permission is refused", async () => {
+    isPermissionGranted.mockResolvedValue(false);
+    requestPermission.mockResolvedValue("denied");
+    const onError = vi.fn();
+    const user = userEvent.setup();
+
+    render(<NotificationDemo onError={onError} />);
+    await user.click(screen.getByRole("button", { name: i18n.t("demo.notification.send") }));
+
+    expect(onError).toHaveBeenCalledWith(i18n.t("demo.notification.denied"));
+    expect(sendNotification).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(
+        screen.getByText(i18n.t("demo.notification.permissionNotGranted")),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/routes/demo.tsx
+++ b/src/routes/demo.tsx
@@ -81,8 +81,13 @@ function FileDemo({ onError }: DemoSectionProps) {
 }
 
 // APP-02: ネイティブ通知
-function NotificationDemo({ onError }: DemoSectionProps) {
+export function NotificationDemo({ onError }: DemoSectionProps) {
   const { t } = useTranslation();
+  const [permissionGranted, setPermissionGranted] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    isPermissionGranted().then(setPermissionGranted);
+  }, []);
 
   return (
     <section className="flex flex-col gap-2">
@@ -96,6 +101,7 @@ function NotificationDemo({ onError }: DemoSectionProps) {
               // モバイルでは要求フローがデスクトップと異なる（OS のダイアログに委譲される）
               granted = (await requestPermission()) === "granted";
             }
+            setPermissionGranted(granted);
             if (granted) {
               sendNotification({
                 title: t("demo.notification.title"),
@@ -111,6 +117,14 @@ function NotificationDemo({ onError }: DemoSectionProps) {
       >
         {t("demo.notification.send")}
       </Button>
+      <p className="text-xs text-muted-foreground">
+        {permissionGranted === null
+          ? t("demo.notification.permissionChecking")
+          : permissionGranted
+            ? t("demo.notification.permissionGranted")
+            : t("demo.notification.permissionNotGranted")}
+      </p>
+      <p className="text-xs text-muted-foreground">{t("demo.notification.devNote")}</p>
     </section>
   );
 }


### PR DESCRIPTION
## 概要

ネイティブ通知デモのボタンを押しても通知が表示されず、エラーも出ない問題への対応。

## 原因

`pnpm tauri dev` は `.app` バンドルではなく `target/debug/` の生バイナリを直接起動する。macOS の通知センターはバンドル ID を持たないプロセスからの通知をエラーを返さずに破棄するため、`notification:default` の capabilities が正しくても通知が出ない。この推定は Issue #37 の調査時点で capabilities 側の解決状況（`gen/schemas/acl-manifests.json`）を確認済みで、コード上の原因は他に見当たらない。

この環境では GUI 操作を伴う `pnpm tauri build` 後の目視確認ができないため、実機確認は行っていない。挙動そのものより「エラーも出ず黙って失敗する」状態の解消を優先した。

## 変更内容

- `src/routes/demo.tsx` の `NotificationDemo` に `isPermissionGranted()` の結果を常時画面表示する行を追加した（許可済み / 未許可 / 確認中）
- 同コンポーネントに、dev 実行では通知が表示されないことがある旨の注記を追加した
- 上記の注記文言を `src/locales/{ja,en}.json` に追加した
- `docs/architecture.md` に「12. 既知の制約」節を新設し、原因と確認手順を記載した
- `NotificationDemo` を export し、権限状態表示とエラー通知の振る舞いを検証するテスト（`src/routes/demo.test.tsx`）を追加した

## テスト

- `pnpm lint && pnpm typecheck && pnpm test` はすべて通過
- Rust 側のファイルは変更していないため `cargo fmt` / `cargo clippy` は対象外

## 既知の制約

- pre-push hook の `rust-core-test` / `rust-tauri-clippy` は `git diff --name-only @{push} HEAD` を使っており、リモートに存在しない新規ブランチの初回 push では `@{push}` が解決できず失敗する。本 PR の変更に Rust ファイルは含まれないため影響はないが、hook 自体のバグとして別 Issue 化を検討したい

Closes #37