### PR TITLE
chore: 登録済みプラグインと capability の不整合を解消する

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "全プラットフォーム・全 window で共通に必要な最小権限のみ（RS-03 / SEC-03）。プラットフォーム固有の権限は desktop.json / mobile.json に分ける。",
+  "description": "全プラットフォーム・全 window で共通に必要な最小権限のみ（RS-03 / SEC-03）。プラットフォーム固有の権限は desktop.json / mobile.json に分ける。splashscreen window は IPC を使わない静的 HTML（public/splashscreen.html）のため、意図的に windows に含めない（#41）。",
   "windows": ["main"],
   "permissions": ["core:default", "deep-link:default"]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -26,7 +26,13 @@ pub fn run() {
     let builder = specta_bindings::typed_builder();
 
     let mut app_builder = tauri::Builder::default()
+        // RS-07: Rust 側 Builder 登録のみで完結し、フロントから
+        // @tauri-apps/plugin-log を呼ぶ経路が無い（IPC を経由しない）ため、
+        // capabilities に log:default は追加しない（#41）。
         .plugin(logging::plugin())
+        // RS-08: フロントから @tauri-apps/plugin-store を使い始めるまでは
+        // capabilities に store:default を追加しない（投機的な権限追加の禁止、
+        // CLAUDE.md）。使い始める時点で該当 capability に追加すること（#41）。
         .plugin(tauri_plugin_store::Builder::new().build())
         // APP-09: ディープリンク（カスタム URL スキーム）。両プラットフォーム対応。
         // スキームは tauri.conf.json の plugins."deep-link".schemes で定義する。


### PR DESCRIPTION
## 内容

`tauri_plugin_store` / `tauri_plugin_log` は `src-tauri/src/lib.rs` で登録済みだが、フロントから未使用のため対応する capability 権限が無い状態だった。また `tauri.conf.json` の `splashscreen` window がどの capability の `windows` にも含まれていなかった。

いずれも実害は無いが「使い始めた瞬間に踏む地雷」状態だったため、CLAUDE.md の「必要最小限を超える権限追加」禁止に従い、投機的に `store:default` / `log:default` を追加するのではなく、なぜ現時点で権限が不要かを明示した。

- `tauri_plugin_log`: Rust 側の `Builder` 登録のみで完結し、フロントから `@tauri-apps/plugin-log` を呼ぶ経路が無い（IPC を経由しないため capability を必要としない設計）。その旨を `lib.rs` にコメントで明示。
- `tauri_plugin_store`: `docs/architecture.md`（RS-08）に「フロントから `@tauri-apps/plugin-store` で直接読み書きする」設計が明記されているが未着手。使い始める時点で `store:default` を追加すべきことを `lib.rs` にコメントで明示。
- `splashscreen` window: `public/splashscreen.html` は IPC を使わない静的 HTML であり、`close_splashscreen` コマンドは main window 側から呼ばれる設計（`commands/window.rs`）。意図的に capability の `windows` に含めていないことを `default.json` の `description` に明記。

権限そのものは一切追加していない（capabilities への機能追加なし）。

## 確認

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`（capabilities の JSON パースも通過）
- `pnpm lint` / `pnpm typecheck` / `pnpm test`
- `cargo test -p app-core`

Closes #41