### PR TITLE
fix(demo): 自動更新デモの状態を未確認・確認中・更新なし・更新あり・失敗の5つに分離

### DIFF
--- a/src-tauri/src/commands/updater.rs
+++ b/src-tauri/src/commands/updater.rs
@@ -17,12 +17,16 @@ pub struct UpdateInfo {
 #[tauri::command]
 #[specta::specta]
 pub async fn check_for_update(app: AppHandle) -> AppResult<UpdateInfo> {
-    let update = app
-        .updater()
-        .map_err(|e| AppError::Io(e.to_string()))?
-        .check()
-        .await
-        .map_err(|e| AppError::Io(e.to_string()))?;
+    let updater = app.updater().map_err(|e| AppError::Io(e.to_string()))?;
+
+    // 初回リリース前など配信マニフェストが存在しない場合、プラグインは
+    // ReleaseNotFound を返す。これは「取得失敗」ではなく「更新なし」として扱う
+    // （Issue #36）。それ以外のエラーは従来どおりフロントに伝える。
+    let update = match updater.check().await {
+        Ok(update) => update,
+        Err(tauri_plugin_updater::Error::ReleaseNotFound) => None,
+        Err(e) => return Err(AppError::Io(e.to_string())),
+    };
 
     Ok(match update {
         Some(update) => UpdateInfo {

--- a/src/lib/updater-status.test.ts
+++ b/src/lib/updater-status.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { toUpdaterStatus } from "./updater-status";
+
+describe("toUpdaterStatus", () => {
+  it("returns upToDate when no update is available", () => {
+    expect(toUpdaterStatus({ available: false, version: null })).toEqual({ kind: "upToDate" });
+  });
+
+  it("returns available with the version when an update is available", () => {
+    expect(toUpdaterStatus({ available: true, version: "1.2.3" })).toEqual({
+      kind: "available",
+      version: "1.2.3",
+    });
+  });
+
+  it("falls back to upToDate when available is true but version is missing", () => {
+    expect(toUpdaterStatus({ available: true, version: null })).toEqual({ kind: "upToDate" });
+  });
+});

--- a/src/lib/updater-status.ts
+++ b/src/lib/updater-status.ts
@@ -1,0 +1,20 @@
+export type UpdaterStatus =
+  | { kind: "idle" }
+  | { kind: "checking" }
+  | { kind: "upToDate" }
+  | { kind: "available"; version: string }
+  | { kind: "failed"; message: string };
+
+/**
+ * checkForUpdate の結果を UpdaterStatus へ変換する。「未確認」(idle) と
+ * 「確認したが更新なし」(upToDate) を区別するため、呼び出し側で常に
+ * checking → (upToDate | available) の順に遷移させる（Issue #36）。
+ */
+export function toUpdaterStatus(info: {
+  available: boolean;
+  version: string | null;
+}): UpdaterStatus {
+  return info.available && info.version
+    ? { kind: "available", version: info.version }
+    : { kind: "upToDate" };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -37,7 +37,9 @@
       "title": "Auto update",
       "check": "Check for updates",
       "install": "Install v{{version}}",
-      "upToDate": "You're up to date"
+      "checking": "Checking...",
+      "upToDate": "You're up to date",
+      "failed": "Check failed: {{message}}"
     }
   }
 }

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -37,7 +37,9 @@
       "title": "自動アップデート",
       "check": "アップデートを確認",
       "install": "v{{version}} をインストール",
-      "upToDate": "最新版です"
+      "checking": "確認中...",
+      "upToDate": "最新版です",
+      "failed": "確認に失敗しました: {{message}}"
     }
   }
 }

--- a/src/routes/demo.tsx
+++ b/src/routes/demo.tsx
@@ -3,6 +3,7 @@ import { type Note, createNote, deleteNote, listNotes } from "@/lib/api/notes";
 import { type TaskProgress, cancelLongTask, onTaskProgress, startLongTask } from "@/lib/api/tasks";
 import { checkForUpdate, installUpdate } from "@/lib/api/updater";
 import { isDesktop } from "@/lib/platform";
+import { type UpdaterStatus, toUpdaterStatus } from "@/lib/updater-status";
 import { useToastStore } from "@/stores/toast-store";
 import { createFileRoute } from "@tanstack/react-router";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
@@ -272,9 +273,8 @@ function NotesDemo({ onError }: DemoSectionProps) {
 // APP-08: 自動アップデート（デスクトップ専用）
 function UpdaterDemo({ onError }: DemoSectionProps) {
   const { t } = useTranslation();
-  const [checking, setChecking] = useState(false);
+  const [status, setStatus] = useState<UpdaterStatus>({ kind: "idle" });
   const [installing, setInstalling] = useState(false);
-  const [available, setAvailable] = useState<string | null>(null);
 
   return (
     <section className="flex flex-col gap-2">
@@ -282,22 +282,22 @@ function UpdaterDemo({ onError }: DemoSectionProps) {
       <div className="flex gap-2">
         <Button
           variant="outline"
-          disabled={checking}
+          disabled={status.kind === "checking"}
           onClick={async () => {
-            setChecking(true);
+            setStatus({ kind: "checking" });
             try {
               const info = await checkForUpdate();
-              setAvailable(info.available ? (info.version ?? null) : null);
+              setStatus(toUpdaterStatus(info));
             } catch (e) {
-              onError(String(e));
-            } finally {
-              setChecking(false);
+              const message = String(e);
+              setStatus({ kind: "failed", message });
+              onError(message);
             }
           }}
         >
           {t("demo.updater.check")}
         </Button>
-        {available && (
+        {status.kind === "available" && (
           <Button
             disabled={installing}
             onClick={async () => {
@@ -311,12 +311,20 @@ function UpdaterDemo({ onError }: DemoSectionProps) {
               }
             }}
           >
-            {t("demo.updater.install", { version: available })}
+            {t("demo.updater.install", { version: status.version })}
           </Button>
         )}
       </div>
-      {!checking && available === null && (
+      {status.kind === "checking" && (
+        <p className="text-xs text-muted-foreground">{t("demo.updater.checking")}</p>
+      )}
+      {status.kind === "upToDate" && (
         <p className="text-xs text-muted-foreground">{t("demo.updater.upToDate")}</p>
+      )}
+      {status.kind === "failed" && (
+        <p className="text-xs text-destructive">
+          {t("demo.updater.failed", { message: status.message })}
+        </p>
       )}
     </section>
   );


### PR DESCRIPTION
## 概要

自動更新デモで一度も確認していないのに「最新版です」と表示される問題と、確認が失敗しても「最新版です」の表示が残る問題を修正する。

- フロント: `UpdaterDemo` の状態を `available: string | null` の単一値から `UpdaterStatus`（idle / checking / upToDate / available / failed）の判別共用体に分離した。状態遷移ロジックは `src/lib/updater-status.ts` の `toUpdaterStatus` に純粋関数として切り出し、単体テストを追加した。
- Rust: `check_for_update` で `tauri_plugin_updater::Error::ReleaseNotFound` を「更新なし」として扱うようにし、初回リリース前の 404 をエラーとしてフロントに見せないようにした。それ以外のエラーは従来どおり `AppError::Io` として返す。
- `src/locales/{en,ja}.json` に `checking` / `failed` の i18n キーを追加した。

Closes #36

## Test plan

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`（`src/lib/updater-status.test.ts` を追加）
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace`