### PR TITLE
chore(ci): mobile compile check に gradle 依存キャッシュを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,6 +233,11 @@ jobs:
           distribution: "temurin"
           java-version: "17"
 
+      # actions/setup-java の cache: gradle はこの時点でまだ存在しない
+      # src-tauri/gen/android の gradle ファイルをハッシュ対象にできず効果が
+      # 無いため、実行時に検出・保存する setup-gradle を使う。
+      - uses: gradle/actions/setup-gradle@v4
+
       - name: Setup Android NDK
         uses: nttld/setup-ndk@v1
         id: setup-ndk


### PR DESCRIPTION
## Summary
- Mobile compile check (Android) で `actions/setup-java` のキャッシュ機能ではなく
  `gradle/actions/setup-gradle` を追加し、Gradle 依存をキャッシュする
- `src-tauri/gen/android` は `cargo tauri android init` で実行時に生成されるため、
  `actions/setup-java` の `cache: gradle` はこの時点で存在しないファイルをハッシュ
  対象にでき効果が無い。`setup-gradle` は実行時に検出・保存するため、生成タイミング
  に依存せずキャッシュできる
- 今回 PR #50 の CI で Mobile compile check が Maven Central への一時的な
  TLS handshake 失敗で落ちた（依存取得自体が失敗し再実行で解消した）ことを踏まえ、
  キャッシュにより依存取得の頻度を下げて再発を抑える狙い

Issue 対応ではない（CI の信頼性向上のための改善）。

## Test plan
- [x] `actionlint .github/workflows/ci.yml`
- [ ] CI の Mobile compile check (Android) が pass することを確認する